### PR TITLE
style: Center tech card items in container and resize in mobile

### DIFF
--- a/src/components/TechCard.astro
+++ b/src/components/TechCard.astro
@@ -8,7 +8,7 @@ import { Image } from 'astro:assets';
   <Image
     src={url}
     alt={alt}
-    class="w-20 h-20"
+    class="size-14 md:size-20"
     width={80}
     height={80}
     loading="eager"

--- a/src/layouts/Main.astro
+++ b/src/layouts/Main.astro
@@ -61,7 +61,7 @@ const { title } = Astro.props;
     />
   </head>
 
-  <body class="overflow-x-hidden">
+  <body class="overflow-x-hidden min-h-[100dvh]">
     <main>
       <NavigationBar />
       <slot />

--- a/src/pages/techStack.astro
+++ b/src/pages/techStack.astro
@@ -63,7 +63,7 @@ import { techCardsData } from '../data/data';
   </p>
 
   <div
-    class="grid-container justify-items-center relative grid grid-cols-4 grid-rows-3 p-4 border-2 border-gray-200 dark:border-gray-700 mt-8 rounded-3xl tech-cards"
+    class="grid-container w-full h-screen max-h-[320px] md:max-h-[500px] justify-items-center gap-2 items-center relative grid grid-cols-4 grid-rows-3 p-4 border-2 border-gray-200 dark:border-gray-700 mt-8 rounded-3xl tech-cards"
   >
     {
       techCardsData.map(techCard => (
@@ -78,11 +78,6 @@ import { techCardsData } from '../data/data';
 </Main>
 
 <style>
-  .grid-container {
-    width: 100%;
-    height: 500px;
-  }
-
   .animated-text {
     opacity: 0;
     transform: translateY(20px);


### PR DESCRIPTION
Hello, i liked view your template in the Astro page. 
Made a small adjustment to the styling of skills so they appear centered on the grid and are responsive on mobile devices.

I hope that helps.

## Image
![Captura de pantalla 2024-07-09 163611](https://github.com/Marve10s/Elkamali-Portfolio-Template/assets/92123185/c738cdb3-9a82-45c0-b4eb-80dd102b5a21)
